### PR TITLE
feat: render Vaadin status-bar icon & add UI test

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -5,6 +5,9 @@ Bundle-SymbolicName: vaadin-eclipse-plugin;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Vaadin
 Require-Bundle: org.eclipse.ui,\
+ org.eclipse.core.expressions;resolution:=optional,\
+ org.eclipse.jdt.core;resolution:=optional,\
+ org.eclipse.core.resources;resolution:=optional,\
  org.junit;resolution:=optional,\
  org.eclipse.ui.workbench;resolution:=optional,\
  org.eclipse.ui.tests;resolution:=optional

--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -4,6 +4,9 @@ Bundle-Name: Vaadin Eclipse Plugin
 Bundle-SymbolicName: vaadin-eclipse-plugin;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Vaadin
-Require-Bundle: org.eclipse.ui
+Require-Bundle: org.eclipse.ui,\
+ org.junit;resolution:=optional,\
+ org.eclipse.ui.workbench;resolution:=optional,\
+ org.eclipse.ui.tests;resolution:=optional
 Automatic-Module-Name: vaadin.eclipse.plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # eclipse-plugin
 
-This Eclipse plugin displays a Vaadin logo in the bottom right of the Eclipse status bar when the plugin is active.
+This Eclipse plugin:
+- Displays a Vaadin logo in the bottom right of the Eclipse status bar when the plugin is active.
+- Auto-detects Vaadin projects (projects containing Vaadin on their classpath) and only enables menu, toolbar, and status-bar contributions when such a project is selected.
 
-A JUnit plug-in test (IconPresenceTest) in `src-test/` launches the IDE, interrogates the status bar, and asserts that the Vaadin logo contribution (ID `vaadin-eclipse-plugin.toolbars.statusLogo`) is actually rendered after Eclipse starts.
+A JUnit plug-in test (IconPresenceTest) in `src-test/` launches the IDE, interrogates the status bar, and asserts that the Vaadin logo contribution (ID `vaadin-eclipse-plugin.toolbars.statusLogo`) is actually rendered.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # eclipse-plugin
+
+This Eclipse plugin displays a Vaadin logo in the bottom right of the Eclipse status bar when the plugin is active.
+
+A JUnit plug-in test (IconPresenceTest) in `src-test/` launches the IDE, interrogates the status bar, and asserts that the Vaadin logo contribution (ID `vaadin-eclipse-plugin.toolbars.statusLogo`) is actually rendered after Eclipse starts.

--- a/build.properties
+++ b/build.properties
@@ -1,5 +1,7 @@
 source.. = src/
+source.test = src-test/
 output.. = bin/
+output.test = test-bin/
 bin.includes = plugin.xml,\
                META-INF/,\
                .,\

--- a/plugin.xml
+++ b/plugin.xml
@@ -57,6 +57,18 @@
             </command>
          </toolbar>
       </menuContribution>
+
+      <menuContribution
+            locationURI="statusLine:org.eclipse.ui.statusLine?after=additions">
+         <toolbar id="vaadin-eclipse-plugin.toolbars.statusLogoToolbar">
+            <command
+                  id="vaadin-eclipse-plugin.toolbars.statusLogo"
+                  commandId="vaadin-eclipse-plugin.commands.sampleCommand"
+                  icon="icons/sample.png"
+                  tooltip="Vaadin Plugin active">
+            </command>
+         </toolbar>
+      </menuContribution>
    </extension>
 
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -30,6 +30,15 @@
             sequence="M1+6">
       </key>
    </extension>
+   <extension point="org.eclipse.core.expressions.propertyTesters">
+      <propertyTester
+            namespace="com.vaadin.plugin"
+            properties="isVaadinProject"
+            type="org.eclipse.core.resources.IProject"
+            class="com.vaadin.plugin.VaadinProjectPropertyTester"
+            forcePluginActivation="true">
+      </propertyTester>
+   </extension>
    <extension
          point="org.eclipse.ui.menus">
       <menuContribution
@@ -42,6 +51,13 @@
                   commandId="vaadin-eclipse-plugin.commands.sampleCommand"
                   id="vaadin-eclipse-plugin.menus.sampleCommand"
                   mnemonic="S">
+               <visibleWhen>
+                  <with variable="selection">
+                     <iterate operator="or">
+                        <test property="com.vaadin.plugin.isVaadinProject"/>
+                     </iterate>
+                  </with>
+               </visibleWhen>
             </command>
          </menu>
       </menuContribution>
@@ -54,6 +70,13 @@
                   commandId="vaadin-eclipse-plugin.commands.sampleCommand"
                   icon="icons/sample.png"
                   tooltip="Say hello world">
+               <visibleWhen>
+                  <with variable="selection">
+                     <iterate operator="or">
+                        <test property="com.vaadin.plugin.isVaadinProject"/>
+                     </iterate>
+                  </with>
+               </visibleWhen>
             </command>
          </toolbar>
       </menuContribution>
@@ -66,6 +89,13 @@
                   commandId="vaadin-eclipse-plugin.commands.sampleCommand"
                   icon="icons/sample.png"
                   tooltip="Vaadin Plugin active">
+               <visibleWhen>
+                  <with variable="selection">
+                     <iterate operator="or">
+                        <test property="com.vaadin.plugin.isVaadinProject"/>
+                     </iterate>
+                  </with>
+               </visibleWhen>
             </command>
          </toolbar>
       </menuContribution>

--- a/src-test/com/vaadin/plugin/IconPresenceTest.java
+++ b/src-test/com/vaadin/plugin/IconPresenceTest.java
@@ -1,0 +1,31 @@
+package com.vaadin.plugin;
+
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.internal.WorkbenchWindow;
+import org.eclipse.jface.action.IContributionItem;
+import org.eclipse.jface.action.IStatusLineManager;
+import org.junit.Test;
+
+@SuppressWarnings("restriction")
+public class IconPresenceTest {
+
+    @Test
+    public void testStatusBarIconRendered() throws Exception {
+        final boolean[] found = new boolean[1];
+        Display.getDefault().syncExec(() -> {
+            WorkbenchWindow win = (WorkbenchWindow) PlatformUI.getWorkbench()
+                    .getActiveWorkbenchWindow();
+            IStatusLineManager mgr = win.getStatusLineManager();
+            for (IContributionItem item : mgr.getItems()) {
+                if ("vaadin-eclipse-plugin.toolbars.statusLogo".equals(item.getId())) {
+                    found[0] = true;
+                    break;
+                }
+            }
+        });
+        assertTrue("Expected Vaadin status-bar icon to be rendered", found[0]);
+    }
+}

--- a/src/com/vaadin/plugin/VaadinProjectPropertyTester.java
+++ b/src/com/vaadin/plugin/VaadinProjectPropertyTester.java
@@ -1,0 +1,32 @@
+package com.vaadin.plugin;
+
+import org.eclipse.core.expressions.PropertyTester;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+
+public class VaadinProjectPropertyTester extends PropertyTester {
+
+    @Override
+    public boolean test(Object receiver, String property, Object[] args, Object expectedValue) {
+        if (!(receiver instanceof IProject)) {
+            return false;
+        }
+        IProject project = (IProject) receiver;
+        try {
+            if (!project.isOpen() || !project.hasNature(JavaCore.NATURE_ID)) {
+                return false;
+            }
+            IJavaProject javaProject = JavaCore.create(project);
+            for (IClasspathEntry entry : javaProject.getRawClasspath()) {
+                String segment = entry.getPath().lastSegment();
+                if (segment != null && segment.toLowerCase().contains("vaadin")) {
+                    return true;
+                }
+            }
+        } catch (Exception e) {
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## What has been done

- Contribute Vaadin logo to the bottom-right of the Eclipse status bar on plugin activation.
- Added a JUnit plug-in test (`IconPresenceTest`) that launches the workbench and asserts the status-bar icon is rendered.
- Updated `plugin.xml`, `META-INF/MANIFEST.MF`, and `README.md` to document and support the new feature.

## Vaadin project detection

- Added `VaadinProjectPropertyTester` that checks for Vaadin jars on the classpath.
- Updated `plugin.xml` to only display menu, toolbar and status-bar contributions when a Vaadin project is selected.

Closes #18