### PR TITLE
Fix Tycho setup

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,2 @@
--Dtycho-version=4.0.1
+-Dtycho-version=4.0.13
 -Dtycho.disableP2Mirrors=true

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,2 @@
--Dtycho-version=4.0.13
+-Dtycho-version=4.0.1
+-Dtycho.disableP2Mirrors=true

--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -9,4 +9,4 @@ Bundle-Activator: com.vaadin.plugin.Activator
 Bundle-ActivationPolicy: lazy
 Import-Package: org.osgi.framework,com.sun.net.httpserver
 Automatic-Module-Name: vaadin.eclipse.plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-21
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <packaging>eclipse-plugin</packaging>
 
     <properties>
-        <tycho-version>4.0.1</tycho-version>
+        <tycho-version>4.0.13</tycho-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <packaging>eclipse-plugin</packaging>
 
     <properties>
-        <tycho.version>4.0.13</tycho.version>
+        <tycho-version>4.0.1</tycho-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -19,13 +19,32 @@
             <plugin>
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-maven-plugin</artifactId>
-                <version>${tycho.version}</version>
+                <version>${tycho-version}</version>
                 <extensions>true</extensions>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-packaging-plugin</artifactId>
+                <version>${tycho-version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>p2-maven-plugin</artifactId>
+                <version>${tycho-version}</version>
             </plugin>
             <plugin>
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>target-platform-configuration</artifactId>
                 <version>${tycho-version}</version>
+                <configuration>
+                    <environments>
+                        <environment>
+                            <os>linux</os>
+                            <ws>gtk</ws>
+                            <arch>x86_64</arch>
+                        </environment>
+                    </environments>
+                </configuration>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
## Summary
- target Java 17 in the manifest
- configure Tycho 4.0.1 in `maven.config`
- add required Tycho packaging and P2 plugins
- configure target-platform for linux/gtk/x86_64

## Testing
- `mvn help:help`


------
https://chatgpt.com/codex/tasks/task_b_685e5904efc483338395bbbacf85efc1