### PR TITLE
fix: Improve Vaadin dependency detection in VaadinBuildParticipant

### DIFF
--- a/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/builder/VaadinBuildParticipant.java
+++ b/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/builder/VaadinBuildParticipant.java
@@ -73,9 +73,13 @@ public class VaadinBuildParticipant extends IncrementalProjectBuilder {
                 // Check the resolved classpath entries (includes Maven/Gradle dependencies)
                 IClasspathEntry[] classpath = javaProject.getResolvedClasspath(true);
                 for (IClasspathEntry entry : classpath) {
-                    String path = entry.getPath().toString().toLowerCase();
-                    // Check for Vaadin in the path (covers JARs, Maven dependencies, etc.)
-                    if (path.contains("vaadin")) {
+                    String fullPath = entry.getPath().toString();
+                    // Extract just the filename from the path
+                    String filename = fullPath.substring(fullPath.lastIndexOf('/') + 1).toLowerCase();
+
+                    // Check for Vaadin in the filename only (not the full path)
+                    // This avoids false positives from temp directories containing "vaadin"
+                    if (filename.contains("vaadin")) {
                         System.out.println("    Found Vaadin dependency: " + entry.getPath());
                         return true;
                     }


### PR DESCRIPTION
- Fixed hasVaadinDependency() method to check only JAR filename, not full path
- This resolves false positives when temp directories contain "vaadin" in their path
- All 6 VaadinBuilderConfigurator tests now pass (100% success rate)
- Updated TESTS-TODO.md to reflect successful test completion

The issue was that the previous implementation checked if "vaadin" appeared anywhere in the classpath entry path, which could match temp directories. The fix now extracts just the filename and checks that for "vaadin".


