### PR TITLE
fix: allow empty framework selection for walking skeleton

### DIFF
--- a/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/wizards/StarterProjectModel.java
+++ b/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/wizards/StarterProjectModel.java
@@ -24,9 +24,9 @@ public class StarterProjectModel extends AbstractProjectModel {
             url.append("&frameworks=flow,hilla");
         } else if (includeHilla) {
             url.append("&frameworks=hilla");
-        } else {
+        } else if (includeFlow) {
             url.append("&frameworks=flow");
-        }
+        } // else: do not add frameworks parameter if both are false
 
         // Add platform version selection (always include, defaults to "latest")
         String platformVersion = prerelease ? "pre" : "latest";

--- a/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/wizards/VaadinProjectWizardPage.java
+++ b/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/wizards/VaadinProjectWizardPage.java
@@ -459,14 +459,6 @@ public class VaadinProjectWizardPage extends WizardPage {
             return;
         }
 
-        // Validate project type selection
-        if (starterProjectRadio.getSelection()) {
-            if (!flowCheckbox.getSelection() && !hillaCheckbox.getSelection()) {
-                updateStatus("Please select at least one framework (Flow or Hilla)");
-                return;
-            }
-        }
-
         updateStatus(null);
     }
 

--- a/vaadin-eclipse-plugin.tests/src/com/vaadin/plugin/test/StarterProjectModelTest.java
+++ b/vaadin-eclipse-plugin.tests/src/com/vaadin/plugin/test/StarterProjectModelTest.java
@@ -67,7 +67,7 @@ public class StarterProjectModelTest {
 		model.setIncludeFlow(false);
 		model.setIncludeHilla(false);
 		String url = model.getDownloadUrl();
-		assertTrue("Should have frameworks=flow", !url.matches(".*frameworks=.*"));
+		assertTrue("Shouldn't contain frameworks parameter", !url.matches(".*frameworks=.*"));
 
 		// Test Flow only
 		model.setIncludeFlow(true);

--- a/vaadin-eclipse-plugin.tests/src/com/vaadin/plugin/test/StarterProjectModelTest.java
+++ b/vaadin-eclipse-plugin.tests/src/com/vaadin/plugin/test/StarterProjectModelTest.java
@@ -63,10 +63,16 @@ public class StarterProjectModelTest {
 	public void testFrameworkSelection() {
 		model.setProjectName("framework-test");
 
+		// Test Empty selection (neither Flow nor Hilla)
+		model.setIncludeFlow(false);
+		model.setIncludeHilla(false);
+		String url = model.getDownloadUrl();
+		assertTrue("Should have frameworks=flow", !url.matches(".*frameworks=.*"));
+
 		// Test Flow only
 		model.setIncludeFlow(true);
 		model.setIncludeHilla(false);
-		String url = model.getDownloadUrl();
+		url = model.getDownloadUrl();
 		assertTrue("Should have frameworks=flow", url.contains("frameworks=flow"));
 
 		// Test Hilla only

--- a/vaadin-eclipse-plugin.tests/src/com/vaadin/plugin/test/StarterProjectModelTest.java
+++ b/vaadin-eclipse-plugin.tests/src/com/vaadin/plugin/test/StarterProjectModelTest.java
@@ -67,7 +67,7 @@ public class StarterProjectModelTest {
 		model.setIncludeFlow(false);
 		model.setIncludeHilla(false);
 		String url = model.getDownloadUrl();
-		assertTrue("Shouldn't contain frameworks parameter", !url.matches(".*frameworks=.*"));
+		assertFalse("Shouldn't contain frameworks parameter", url.matches(".*frameworks=.*"));
 
 		// Test Flow only
 		model.setIncludeFlow(true);


### PR DESCRIPTION
### Changes

1. **Wizard Validation**

   * `VaadinProjectWizardPage`: Finish button now enabled when both *Flow* and *Hilla* are unchecked.

2. **URL Generation**

   * `StarterProjectModel.getDownloadUrl()`: Omits `frameworks` parameter if both `includeFlow` and `includeHilla` are false.
   * Previously defaulted to `frameworks=flow`, which incorrectly added Flow views.

3. **Updated Tests**

### Fixes

* Users can create a Starter Project with no frameworks selected.
* Generated project contains no unwanted Flow or Hilla code.
* UI behavior and backend requests are now consistent with user choices.

