### PR TITLE
feat: allow user to set the groupId when creating a new project

### DIFF
--- a/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/wizards/AbstractProjectModel.java
+++ b/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/wizards/AbstractProjectModel.java
@@ -10,6 +10,7 @@ public abstract class AbstractProjectModel {
 
     protected String projectName;
     protected String location;
+    protected String groupId = "com.example.application";
 
     /**
      * Get the download URL for this project configuration.
@@ -60,5 +61,13 @@ public abstract class AbstractProjectModel {
 
     public void setLocation(String location) {
         this.location = location;
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
     }
 }

--- a/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/wizards/AbstractProjectModel.java
+++ b/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/wizards/AbstractProjectModel.java
@@ -8,7 +8,7 @@ import java.nio.charset.StandardCharsets;
  */
 public abstract class AbstractProjectModel {
 
-    protected String projectName;
+    protected String projectName = "NewProject";
     protected String location;
     protected String groupId = "com.example.application";
 

--- a/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/wizards/HelloWorldProjectModel.java
+++ b/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/wizards/HelloWorldProjectModel.java
@@ -18,7 +18,7 @@ public class HelloWorldProjectModel extends AbstractProjectModel {
         String artifactId = toArtifactId(projectName);
         url.append("name=").append(encode(artifactId));
         url.append("&artifactId=").append(encode(artifactId));
-        url.append("&groupId=com.example.application");
+        url.append("&groupId=").append(encode(getGroupId()));
 
         // Add framework
         url.append("&framework=").append(framework);

--- a/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/wizards/StarterProjectModel.java
+++ b/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/wizards/StarterProjectModel.java
@@ -17,7 +17,7 @@ public class StarterProjectModel extends AbstractProjectModel {
         String artifactId = toArtifactId(projectName);
         url.append("name=").append(encode(artifactId));
         url.append("&artifactId=").append(encode(artifactId));
-        url.append("&groupId=com.example.application");
+        url.append("&groupId=").append(encode(groupId));
 
         // Add framework selection using the 'frameworks' parameter
         if (includeFlow && includeHilla) {

--- a/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/wizards/VaadinProjectWizardPage.java
+++ b/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/wizards/VaadinProjectWizardPage.java
@@ -439,7 +439,7 @@ public class VaadinProjectWizardPage extends WizardPage {
 
     private String generateProjectName() {
         IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
-        String baseName = "vaadin-project";
+        String baseName = starterModel.getProjectName();
         String projectName = baseName;
         int counter = 1;
 

--- a/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/wizards/VaadinProjectWizardPage.java
+++ b/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/wizards/VaadinProjectWizardPage.java
@@ -453,6 +453,7 @@ public class VaadinProjectWizardPage extends WizardPage {
 
     private void dialogChanged() {
         String projectName = projectNameText.getText();
+        String groupId = groupIdText.getText();
 
         // Update location if using default
         if (useDefaultLocationButton.getSelection()) {
@@ -460,13 +461,16 @@ public class VaadinProjectWizardPage extends WizardPage {
         }
 
         // Validate project name
-        if (projectName.length() == 0) {
-            updateStatus("Project name must be specified");
+        String projectNamePattern = "^[A-Za-z0-9_.-]+$";
+        if (!projectName.matches(projectNamePattern)) {
+            updateStatus("Name must have only letters/digits/underscores/hyphens/dots");
             return;
         }
 
-        if (projectName.contains(" ")) {
-            updateStatus("Project name cannot contain spaces");
+        // Validate group ID
+        String groupIdPattern = "^(?!\\.)(?!.*\\.\\.)(?=.*\\.)([A-Za-z0-9_.]+)(?<!\\.)$";
+        if (!groupId.matches(groupIdPattern)) {
+            updateStatus("Group ID must use letters/digits/underscores/dots, include at least one dot, no leading/trailing or consecutive dots.");
             return;
         }
 
@@ -475,6 +479,7 @@ public class VaadinProjectWizardPage extends WizardPage {
             updateStatus("A project with this name already exists");
             return;
         }
+
 
         updateStatus(null);
     }

--- a/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/wizards/VaadinProjectWizardPage.java
+++ b/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/wizards/VaadinProjectWizardPage.java
@@ -28,6 +28,7 @@ public class VaadinProjectWizardPage extends WizardPage {
     private Text projectNameText;
     private Text locationText;
     private Button useDefaultLocationButton;
+    private Text groupIdText;
 
     // Starter project options
     private Button starterProjectRadio;
@@ -76,6 +77,22 @@ public class VaadinProjectWizardPage extends WizardPage {
         projectNameText.setLayoutData(gd);
         projectNameText.addModifyListener(new ModifyListener() {
             public void modifyText(ModifyEvent e) {
+                dialogChanged();
+            }
+        });
+
+        // Group ID
+        label = new Label(container, SWT.NULL);
+        label.setText("Group ID:");
+        groupIdText = new Text(container, SWT.BORDER | SWT.SINGLE);
+        gd = new GridData(GridData.FILL_HORIZONTAL);
+        gd.horizontalSpan = 2;
+        groupIdText.setLayoutData(gd);
+        groupIdText.setText(starterModel.getGroupId());
+        groupIdText.addModifyListener(new ModifyListener() {
+            public void modifyText(ModifyEvent e) {
+                starterModel.setGroupId(groupIdText.getText());
+                helloWorldModel.setGroupId(groupIdText.getText());
                 dialogChanged();
             }
         });
@@ -475,6 +492,7 @@ public class VaadinProjectWizardPage extends WizardPage {
 
         model.setProjectName(projectNameText.getText());
         model.setLocation(locationText.getText());
+        model.setGroupId(groupIdText.getText());
 
         if (starterProjectRadio != null && starterProjectRadio.getSelection()) {
             starterModel.setProjectName(projectNameText.getText());

--- a/vaadin-eclipse-plugin.tests/src/com/vaadin/plugin/test/HelloWorldProjectModelTest.java
+++ b/vaadin-eclipse-plugin.tests/src/com/vaadin/plugin/test/HelloWorldProjectModelTest.java
@@ -128,4 +128,17 @@ public class HelloWorldProjectModelTest {
 			assertTrue("Should contain stack=" + arch, url.contains("stack=" + arch));
 		}
 	}
+
+	@Test
+	public void testCustomGroupIdInUrl() {
+		model.setProjectName("custom-groupid-test");
+		String customGroupId = "org.example.custom";
+		model.setGroupId(customGroupId);
+
+		String url = model.getDownloadUrl();
+		assertNotNull("URL should be generated", url);
+		// The groupId should be URL-encoded
+		String encodedGroupId = java.net.URLEncoder.encode(customGroupId, java.nio.charset.StandardCharsets.UTF_8);
+		assertTrue("URL should contain the custom groupId", url.contains("groupId=" + encodedGroupId));
+	}
 }

--- a/vaadin-eclipse-plugin.tests/src/com/vaadin/plugin/test/StarterProjectModelTest.java
+++ b/vaadin-eclipse-plugin.tests/src/com/vaadin/plugin/test/StarterProjectModelTest.java
@@ -133,4 +133,16 @@ public class StarterProjectModelTest {
 		String url = model.getDownloadUrl();
 		assertTrue("Should contain platformVersion=latest", url.contains("platformVersion=latest"));
 	}
+
+	@Test
+	public void testCustomGroupIdInUrl() {
+		model.setProjectName("custom-groupid-starter");
+		String customGroupId = "org.example.starter";
+		model.setGroupId(customGroupId);
+
+		String url = model.getDownloadUrl();
+		assertNotNull("URL should be generated", url);
+		String encodedGroupId = java.net.URLEncoder.encode(customGroupId, java.nio.charset.StandardCharsets.UTF_8);
+		assertTrue("URL should contain the custom groupId", url.contains("groupId=" + encodedGroupId));
+	}
 }


### PR DESCRIPTION
**Summary of Modifications**

- Feature:
   -  `HelloWorldProjectModel`:   Fixed the groupId handling in getDownloadUrl() by replacing the hardcoded value with the value set via the model's setter. The groupId in the generated URL now correctly reflects user input from the wizard.

-  Tests:
	-  `HelloWorldProjectModelTest`:  Added testCustomGroupIdInUrl to verify that setting a custom groupId is properly reflected and URL-encoded in the generated download URL.
	-  `StarterProjectModelTest`:  Added testCustomGroupIdInUrl to ensure the same groupId handling is tested for starter projects.

- Other changes:
      - Align defaults with other plugins by setting them to `NewProject` and `com.example.application`
      - Align validations with other plugins

related to: https://github.com/vaadin/copilot/issues/96

