### PR TITLE
refactor: Replace System.out/err with proper Eclipse logging

### DIFF
--- a/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/Activator.java
+++ b/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/Activator.java
@@ -6,6 +6,7 @@ import org.osgi.framework.BundleContext;
 
 import com.vaadin.plugin.debug.SilentExceptionFilter;
 import com.vaadin.plugin.launch.ServerLaunchListener;
+import com.vaadin.plugin.util.VaadinPluginLog;
 
 /**
  * Bundle activator that starts the REST service when the plug-in is activated and stops it on shutdown.
@@ -37,8 +38,7 @@ public class Activator implements BundleActivator {
             // Update all dotfiles with the current endpoint
             dotfileManager.updateAllDotfiles();
         } catch (Exception e) {
-            System.err.println("Failed to start Vaadin Eclipse Plugin: " + e.getMessage());
-            e.printStackTrace();
+            VaadinPluginLog.error("Failed to start Vaadin Eclipse Plugin: " + e.getMessage(), e);
             // Clean up any partially initialized resources
             stop(context);
             throw e;

--- a/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/CopilotClient.java
+++ b/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/CopilotClient.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.vaadin.plugin.util.VaadinPluginLog;
 
 /**
  * Client for communicating with the Copilot REST service.
@@ -128,7 +129,7 @@ public class CopilotClient {
         HttpResponse<String> response = send(command, dataCommand);
 
         if (response.statusCode() != 200) {
-            System.err.println("Unexpected response (" + response.statusCode() + ") communicating with the IDE plugin: "
+            VaadinPluginLog.error("Unexpected response (" + response.statusCode() + ") communicating with the IDE plugin: "
                     + response.body());
             return Optional.empty();
         }

--- a/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/CopilotDotfileManager.java
+++ b/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/CopilotDotfileManager.java
@@ -19,6 +19,7 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
+import com.vaadin.plugin.util.VaadinPluginLog;
 
 /**
  * Manages the .copilot-plugin dotfile for Vaadin projects. Creates the dotfile in .eclipse folder when a Vaadin project
@@ -107,7 +108,7 @@ public class CopilotDotfileManager implements IResourceChangeListener {
                     }
                 });
             } catch (CoreException e) {
-                e.printStackTrace();
+                VaadinPluginLog.error("Error in resource change listener", e);
             }
         } else if (event.getType() == IResourceChangeEvent.PRE_CLOSE
                 || event.getType() == IResourceChangeEvent.PRE_DELETE) {
@@ -223,17 +224,16 @@ public class CopilotDotfileManager implements IResourceChangeListener {
                     }
                 } catch (CoreException e) {
                     // Log but don't fail - refresh is not critical
-                    System.err.println("Failed to refresh project " + project.getName() + ": " + e.getMessage());
+                    VaadinPluginLog.error("Failed to refresh project " + project.getName() + ": " + e.getMessage());
                 }
             });
             refreshJob.setRule(project);
             refreshJob.schedule(100); // Small delay to ensure resource tree is unlocked
 
-            System.out.println("Created .copilot-plugin dotfile for project: " + project.getName());
+            VaadinPluginLog.info("Created .copilot-plugin dotfile for project: " + project.getName());
 
         } catch (Exception e) {
-            System.err.println("Failed to create dotfile for project " + project.getName() + ": " + e.getMessage());
-            e.printStackTrace();
+            VaadinPluginLog.error("Failed to create dotfile for project " + project.getName() + ": " + e.getMessage(), e);
         }
     }
 
@@ -250,11 +250,11 @@ public class CopilotDotfileManager implements IResourceChangeListener {
             Path dotfilePath = Paths.get(projectLocation.toString(), ECLIPSE_FOLDER, DOTFILE_NAME);
             if (Files.exists(dotfilePath)) {
                 Files.delete(dotfilePath);
-                System.out.println("Removed .copilot-plugin dotfile for project: " + project.getName());
+                VaadinPluginLog.info("Removed .copilot-plugin dotfile for project: " + project.getName());
             }
 
         } catch (Exception e) {
-            System.err.println("Failed to remove dotfile for project " + project.getName() + ": " + e.getMessage());
+            VaadinPluginLog.error("Failed to remove dotfile for project " + project.getName() + ": " + e.getMessage());
         }
     }
 

--- a/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/CopilotUndoManager.java
+++ b/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/CopilotUndoManager.java
@@ -21,6 +21,7 @@ import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.texteditor.ITextEditor;
+import com.vaadin.plugin.util.VaadinPluginLog;
 
 /**
  * Manages undo/redo operations for Copilot file modifications.
@@ -74,8 +75,7 @@ public class CopilotUndoManager {
             fileOperations.computeIfAbsent(filePath, k -> new ArrayList<>()).add(operation);
 
         } catch (Exception e) {
-            System.err.println("Failed to record operation: " + e.getMessage());
-            e.printStackTrace();
+            VaadinPluginLog.error("Failed to record operation: " + e.getMessage(), e);
         }
     }
 
@@ -116,8 +116,7 @@ public class CopilotUndoManager {
                 }
             }
         } catch (Exception e) {
-            System.err.println("Error performing undo: " + e.getMessage());
-            e.printStackTrace();
+            VaadinPluginLog.error("Error performing undo: " + e.getMessage(), e);
         }
 
         return performed;
@@ -144,8 +143,7 @@ public class CopilotUndoManager {
                 }
             }
         } catch (Exception e) {
-            System.err.println("Error performing redo: " + e.getMessage());
-            e.printStackTrace();
+            VaadinPluginLog.error("Error performing redo: " + e.getMessage(), e);
         }
 
         return performed;

--- a/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/CopilotUtil.java
+++ b/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/CopilotUtil.java
@@ -3,6 +3,7 @@ package com.vaadin.plugin;
 import java.util.Arrays;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import com.vaadin.plugin.util.VaadinPluginLog;
 
 /**
  * Utility class for Copilot integration.
@@ -41,10 +42,9 @@ public class CopilotUtil {
                 props.store(fos, "Vaadin Copilot Integration Runtime Properties");
             }
 
-            System.out.println("Created copilot dotfile at: " + dotFile.getAbsolutePath());
+            VaadinPluginLog.info("Created copilot dotfile at: " + dotFile.getAbsolutePath());
         } catch (Exception e) {
-            System.err.println("Failed to create copilot dotfile: " + e.getMessage());
-            e.printStackTrace();
+            VaadinPluginLog.error("Failed to create copilot dotfile: " + e.getMessage(), e);
         }
     }
 }

--- a/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/builder/VaadinBuildParticipant.java
+++ b/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/builder/VaadinBuildParticipant.java
@@ -20,6 +20,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.vaadin.plugin.util.VaadinPluginLog;
 
 /**
  * Build participant that generates files in the output folder during compilation. These files will be automatically
@@ -35,23 +36,23 @@ public class VaadinBuildParticipant extends IncrementalProjectBuilder {
             throws CoreException {
 
         IProject project = getProject();
-        System.out.println(
+        VaadinPluginLog.debug(
                 "VaadinBuildParticipant.build() called for project: " + (project != null ? project.getName() : "null"));
 
         if (project == null || !project.isAccessible()) {
-            System.out.println("  - Project is null or not accessible");
+            VaadinPluginLog.debug("  - Project is null or not accessible");
             return null;
         }
 
         // Check if this is a Java project
         if (!project.hasNature(JavaCore.NATURE_ID)) {
-            System.out.println("  - Not a Java project");
+            VaadinPluginLog.debug("  - Not a Java project");
             return null;
         }
 
         // Check if project has Vaadin dependencies
         boolean hasVaadin = hasVaadinDependency(project);
-        System.out.println("  - Has Vaadin dependencies: " + hasVaadin);
+        VaadinPluginLog.debug("  - Has Vaadin dependencies: " + hasVaadin);
 
         if (!hasVaadin) {
             return null;
@@ -80,14 +81,14 @@ public class VaadinBuildParticipant extends IncrementalProjectBuilder {
                     // Check for Vaadin in the filename only (not the full path)
                     // This avoids false positives from temp directories containing "vaadin"
                     if (filename.contains("vaadin")) {
-                        System.out.println("    Found Vaadin dependency: " + entry.getPath());
+                        VaadinPluginLog.debug("    Found Vaadin dependency: " + entry.getPath());
                         return true;
                     }
                 }
             }
         } catch (Exception e) {
             // If we can't determine, assume no Vaadin dependency
-            System.err.println("Error checking for Vaadin dependencies: " + e.getMessage());
+            VaadinPluginLog.error("Error checking for Vaadin dependencies: " + e.getMessage());
         }
 
         return false;
@@ -167,10 +168,10 @@ public class VaadinBuildParticipant extends IncrementalProjectBuilder {
             vaadinFolder.setDerived(true, monitor);
             configFolder.setDerived(true, monitor);
 
-            System.out.println("Updated flow-build-info.json in output folder: " + configFolder.getFullPath());
+            VaadinPluginLog.info("Updated flow-build-info.json in output folder: " + configFolder.getFullPath());
 
         } catch (Exception e) {
-            System.err.println("Failed to update flow-build-info.json: " + e.getMessage());
+            VaadinPluginLog.error("Failed to update flow-build-info.json: " + e.getMessage());
         }
     }
 

--- a/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/builder/VaadinBuilderConfigurator.java
+++ b/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/builder/VaadinBuilderConfigurator.java
@@ -10,6 +10,8 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.JavaCore;
 
+import com.vaadin.plugin.util.VaadinPluginLog;
+
 /**
  * Automatically adds the Vaadin builder to Java projects. The builder itself will check for Vaadin dependencies.
  */
@@ -20,13 +22,13 @@ public class VaadinBuilderConfigurator implements IResourceChangeListener {
     public static void initialize() {
         if (instance == null) {
             instance = new VaadinBuilderConfigurator();
-            System.out.println("VaadinBuilderConfigurator: Initializing...");
+            VaadinPluginLog.info("VaadinBuilderConfigurator: Initializing...");
 
             ResourcesPlugin.getWorkspace().addResourceChangeListener(instance, IResourceChangeEvent.POST_CHANGE);
 
             // Configure existing projects
             IProject[] projects = ResourcesPlugin.getWorkspace().getRoot().getProjects();
-            System.out.println("VaadinBuilderConfigurator: Found " + projects.length + " projects");
+            VaadinPluginLog.info("VaadinBuilderConfigurator: Found " + projects.length + " projects");
 
             for (IProject project : projects) {
                 instance.configureProject(project);
@@ -62,15 +64,15 @@ public class VaadinBuilderConfigurator implements IResourceChangeListener {
 
     private void configureProject(IProject project) {
         try {
-            System.out.println("VaadinBuilderConfigurator: Checking project " + project.getName());
+            VaadinPluginLog.debug("VaadinBuilderConfigurator: Checking project " + project.getName());
 
             if (!project.isOpen()) {
-                System.out.println("  - Project is not open");
+                VaadinPluginLog.debug("  - Project is not open");
                 return;
             }
 
             if (!project.hasNature(JavaCore.NATURE_ID)) {
-                System.out.println("  - Not a Java project");
+                VaadinPluginLog.debug("  - Not a Java project");
                 return;
             }
 
@@ -80,7 +82,7 @@ public class VaadinBuilderConfigurator implements IResourceChangeListener {
             // Check if builder is already present
             for (ICommand command : commands) {
                 if (VaadinBuildParticipant.BUILDER_ID.equals(command.getBuilderName())) {
-                    System.out.println("  - Builder already configured");
+                    VaadinPluginLog.debug("  - Builder already configured");
                     return; // Already configured
                 }
             }
@@ -96,10 +98,10 @@ public class VaadinBuilderConfigurator implements IResourceChangeListener {
             desc.setBuildSpec(newCommands);
             project.setDescription(desc, null);
 
-            System.out.println("  - Added Vaadin builder to project: " + project.getName());
+            VaadinPluginLog.info("  - Added Vaadin builder to project: " + project.getName());
 
         } catch (CoreException e) {
-            System.out.println("  - Error configuring project: " + e.getMessage());
+            VaadinPluginLog.warning("  - Error configuring project: " + e.getMessage(), e);
         }
     }
 

--- a/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/debug/SilentExceptionFilter.java
+++ b/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/debug/SilentExceptionFilter.java
@@ -6,6 +6,7 @@ import org.eclipse.debug.core.IDebugEventSetListener;
 import org.eclipse.debug.core.model.IBreakpoint;
 import org.eclipse.jdt.debug.core.IJavaExceptionBreakpoint;
 import org.eclipse.jdt.debug.core.IJavaThread;
+import com.vaadin.plugin.util.VaadinPluginLog;
 
 /**
  * Debug event listener that filters out SilentException breakpoints to prevent the debugger from stopping unnecessarily
@@ -43,7 +44,7 @@ public class SilentExceptionFilter implements IDebugEventSetListener {
                             }
                         }
                     } catch (Exception e) {
-                        System.err.println("Error handling debug event: " + e.getMessage());
+                        VaadinPluginLog.error("Error handling debug event: " + e.getMessage());
                     }
                 }
             }

--- a/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/hotswap/HotswapAgentManager.java
+++ b/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/hotswap/HotswapAgentManager.java
@@ -15,6 +15,7 @@ import java.util.jar.Manifest;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Platform;
 import org.osgi.framework.Bundle;
+import com.vaadin.plugin.util.VaadinPluginLog;
 
 /**
  * Manages the Hotswap Agent installation and updates. Handles downloading, installing, and version management of
@@ -51,7 +52,7 @@ public class HotswapAgentManager {
         try {
             Files.createDirectories(vaadinHomePath);
         } catch (IOException e) {
-            System.err.println("Failed to create Vaadin home directory: " + e.getMessage());
+            VaadinPluginLog.error("Failed to create Vaadin home directory: " + e.getMessage());
         }
     }
 
@@ -103,16 +104,15 @@ public class HotswapAgentManager {
                 try (InputStream in = fileUrl.openStream()) {
                     Files.copy(in, hotswapAgentPath, StandardCopyOption.REPLACE_EXISTING);
                 }
-                System.out.println("Installed Hotswap Agent version: " + bundledVersion);
+                VaadinPluginLog.info("Installed Hotswap Agent version: " + bundledVersion);
                 return bundledVersion;
             } else {
-                System.out.println("Hotswap Agent is up to date: " + installedVersion);
+                VaadinPluginLog.info("Hotswap Agent is up to date: " + installedVersion);
                 return installedVersion;
             }
 
         } catch (Exception e) {
-            System.err.println("Failed to install Hotswap Agent: " + e.getMessage());
-            e.printStackTrace();
+            VaadinPluginLog.error("Failed to install Hotswap Agent: " + e.getMessage(), e);
             return null;
         }
     }

--- a/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/hotswap/JetBrainsRuntimeManager.java
+++ b/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/hotswap/JetBrainsRuntimeManager.java
@@ -15,6 +15,7 @@ import org.eclipse.jdt.launching.IVMInstall;
 import org.eclipse.jdt.launching.IVMInstallType;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jdt.launching.VMStandin;
+import com.vaadin.plugin.util.VaadinPluginLog;
 
 /**
  * Manages JetBrains Runtime (JBR) installation and configuration. JBR is required for enhanced class redefinition
@@ -56,7 +57,7 @@ public class JetBrainsRuntimeManager {
         try {
             Files.createDirectories(jbrInstallPath);
         } catch (IOException e) {
-            System.err.println("Failed to create JBR directory: " + e.getMessage());
+            VaadinPluginLog.error("Failed to create JBR directory: " + e.getMessage());
         }
     }
 
@@ -203,7 +204,7 @@ public class JetBrainsRuntimeManager {
             monitor.subTask("Downloading JBR...");
             // Download logic would go here
             // For now, we'll just print a message
-            System.out.println("Would download JBR from: " + downloadUrl);
+            VaadinPluginLog.debug("Would download JBR from: " + downloadUrl);
 
             monitor.worked(50);
 
@@ -220,8 +221,7 @@ public class JetBrainsRuntimeManager {
             return null; // Would return the installed JBR
 
         } catch (Exception e) {
-            System.err.println("Failed to download JBR: " + e.getMessage());
-            e.printStackTrace();
+            VaadinPluginLog.error("Failed to download JBR: " + e.getMessage(), e);
             return null;
         } finally {
             monitor.done();
@@ -260,8 +260,7 @@ public class JetBrainsRuntimeManager {
             return vm;
 
         } catch (Exception e) {
-            System.err.println("Failed to register JBR: " + e.getMessage());
-            e.printStackTrace();
+            VaadinPluginLog.error("Failed to register JBR: " + e.getMessage(), e);
             return null;
         }
     }

--- a/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/launch/ServerLaunchListener.java
+++ b/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/launch/ServerLaunchListener.java
@@ -8,6 +8,7 @@ import org.eclipse.debug.core.ILaunchListener;
 import org.eclipse.wst.server.core.IModule;
 import org.eclipse.wst.server.core.IServer;
 import org.eclipse.wst.server.core.ServerUtil;
+import com.vaadin.plugin.util.VaadinPluginLog;
 
 /**
  * Listener that hooks into server launch events to trigger a build for Vaadin projects. The Vaadin builder will
@@ -46,7 +47,7 @@ public class ServerLaunchListener implements ILaunchListener {
 
         } catch (Exception e) {
             // Log but don't fail the launch
-            System.err.println("Failed to trigger build: " + e.getMessage());
+            VaadinPluginLog.error("Failed to trigger build: " + e.getMessage());
         }
     }
 

--- a/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/util/ResourceReader.java
+++ b/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/util/ResourceReader.java
@@ -30,7 +30,7 @@ public class ResourceReader {
                 }
             }
         } catch (IOException e) {
-            System.err.println("Failed to read flow-build-info.json resource: " + e.getMessage());
+            VaadinPluginLog.error("Failed to read flow-build-info.json resource: " + e.getMessage());
         }
         return null;
     }
@@ -49,9 +49,9 @@ public class ResourceReader {
     public static void exampleUsage() {
         String content = readFlowBuildInfo();
         if (content != null) {
-            System.out.println("flow-build-info.json content: " + content);
+            VaadinPluginLog.info("flow-build-info.json content: " + content);
         } else {
-            System.out.println("flow-build-info.json resource not found in classpath");
+            VaadinPluginLog.info("flow-build-info.json resource not found in classpath");
         }
     }
 }

--- a/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/util/VaadinPluginLog.java
+++ b/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/util/VaadinPluginLog.java
@@ -5,6 +5,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * Utility class for logging messages in the Vaadin Eclipse Plugin.
@@ -12,11 +13,16 @@ import org.osgi.framework.Bundle;
  */
 public class VaadinPluginLog {
     
-    private static final String PLUGIN_ID = "com.vaadin.eclipse.plugin";
+    private static final String PLUGIN_ID = "vaadin-eclipse-plugin";
     private static ILog log;
     
     static {
+        // Try to get the bundle using the correct plugin ID
         Bundle bundle = Platform.getBundle(PLUGIN_ID);
+        if (bundle == null) {
+            // Fallback: try to get the bundle from a class in this plugin
+            bundle = FrameworkUtil.getBundle(VaadinPluginLog.class);
+        }
         if (bundle != null) {
             log = Platform.getLog(bundle);
         }

--- a/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/util/VaadinPluginLog.java
+++ b/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/util/VaadinPluginLog.java
@@ -1,0 +1,93 @@
+package com.vaadin.plugin.util;
+
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Status;
+import org.osgi.framework.Bundle;
+
+/**
+ * Utility class for logging messages in the Vaadin Eclipse Plugin.
+ * Provides methods for logging at different levels (info, warning, error, debug).
+ */
+public class VaadinPluginLog {
+    
+    private static final String PLUGIN_ID = "com.vaadin.eclipse.plugin";
+    private static ILog log;
+    
+    static {
+        Bundle bundle = Platform.getBundle(PLUGIN_ID);
+        if (bundle != null) {
+            log = Platform.getLog(bundle);
+        }
+    }
+    
+    /**
+     * Logs an informational message.
+     * 
+     * @param message the message to log
+     */
+    public static void info(String message) {
+        if (log != null) {
+            log.log(new Status(IStatus.INFO, PLUGIN_ID, message));
+        }
+    }
+    
+    /**
+     * Logs a warning message.
+     * 
+     * @param message the message to log
+     */
+    public static void warning(String message) {
+        if (log != null) {
+            log.log(new Status(IStatus.WARNING, PLUGIN_ID, message));
+        }
+    }
+    
+    /**
+     * Logs a warning message with an exception.
+     * 
+     * @param message the message to log
+     * @param exception the exception to log
+     */
+    public static void warning(String message, Throwable exception) {
+        if (log != null) {
+            log.log(new Status(IStatus.WARNING, PLUGIN_ID, message, exception));
+        }
+    }
+    
+    /**
+     * Logs an error message.
+     * 
+     * @param message the message to log
+     */
+    public static void error(String message) {
+        if (log != null) {
+            log.log(new Status(IStatus.ERROR, PLUGIN_ID, message));
+        }
+    }
+    
+    /**
+     * Logs an error message with an exception.
+     * 
+     * @param message the message to log
+     * @param exception the exception to log
+     */
+    public static void error(String message, Throwable exception) {
+        if (log != null) {
+            log.log(new Status(IStatus.ERROR, PLUGIN_ID, message, exception));
+        }
+    }
+    
+    /**
+     * Logs a debug message. Debug messages are always logged at INFO level
+     * to help diagnose issues without requiring Eclipse to be in debug mode.
+     * 
+     * @param message the message to log
+     */
+    public static void debug(String message) {
+        if (log != null) {
+            log.log(new Status(IStatus.INFO, PLUGIN_ID, "[DEBUG] " + message));
+        }
+    }
+}

--- a/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/util/VaadinPluginLog.java
+++ b/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/util/VaadinPluginLog.java
@@ -1,32 +1,13 @@
 package com.vaadin.plugin.util;
 
 import org.eclipse.core.runtime.ILog;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.Status;
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 /**
  * Utility class for logging messages in the Vaadin Eclipse Plugin.
- * Provides methods for logging at different levels (info, warning, error, debug).
+ * Uses the simplified ILog.get() approach available since Eclipse 2021-03.
+ * Each call automatically uses the logger for the calling class's bundle.
  */
 public class VaadinPluginLog {
-    
-    private static final String PLUGIN_ID = "vaadin-eclipse-plugin";
-    private static ILog log;
-    
-    static {
-        // Try to get the bundle using the correct plugin ID
-        Bundle bundle = Platform.getBundle(PLUGIN_ID);
-        if (bundle == null) {
-            // Fallback: try to get the bundle from a class in this plugin
-            bundle = FrameworkUtil.getBundle(VaadinPluginLog.class);
-        }
-        if (bundle != null) {
-            log = Platform.getLog(bundle);
-        }
-    }
     
     /**
      * Logs an informational message.
@@ -34,9 +15,7 @@ public class VaadinPluginLog {
      * @param message the message to log
      */
     public static void info(String message) {
-        if (log != null) {
-            log.log(new Status(IStatus.INFO, PLUGIN_ID, message));
-        }
+        ILog.get().info(message);
     }
     
     /**
@@ -45,9 +24,7 @@ public class VaadinPluginLog {
      * @param message the message to log
      */
     public static void warning(String message) {
-        if (log != null) {
-            log.log(new Status(IStatus.WARNING, PLUGIN_ID, message));
-        }
+        ILog.get().warn(message);
     }
     
     /**
@@ -57,9 +34,7 @@ public class VaadinPluginLog {
      * @param exception the exception to log
      */
     public static void warning(String message, Throwable exception) {
-        if (log != null) {
-            log.log(new Status(IStatus.WARNING, PLUGIN_ID, message, exception));
-        }
+        ILog.get().warn(message, exception);
     }
     
     /**
@@ -68,9 +43,7 @@ public class VaadinPluginLog {
      * @param message the message to log
      */
     public static void error(String message) {
-        if (log != null) {
-            log.log(new Status(IStatus.ERROR, PLUGIN_ID, message));
-        }
+        ILog.get().error(message);
     }
     
     /**
@@ -80,9 +53,7 @@ public class VaadinPluginLog {
      * @param exception the exception to log
      */
     public static void error(String message, Throwable exception) {
-        if (log != null) {
-            log.log(new Status(IStatus.ERROR, PLUGIN_ID, message, exception));
-        }
+        ILog.get().error(message, exception);
     }
     
     /**
@@ -92,8 +63,6 @@ public class VaadinPluginLog {
      * @param message the message to log
      */
     public static void debug(String message) {
-        if (log != null) {
-            log.log(new Status(IStatus.INFO, PLUGIN_ID, "[DEBUG] " + message));
-        }
+        ILog.get().info("[DEBUG] " + message);
     }
 }

--- a/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/wizards/NewVaadinProjectWizard.java
+++ b/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/wizards/NewVaadinProjectWizard.java
@@ -35,6 +35,7 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.ide.IDE;
 
 import com.vaadin.plugin.CopilotDotfileManager;
+import com.vaadin.plugin.util.VaadinPluginLog;
 
 /**
  * New Vaadin Project creation wizard.
@@ -217,7 +218,7 @@ public class NewVaadinProjectWizard extends Wizard implements INewWizard {
     private IProject importMavenProject(Path projectPath, String projectName, IProgressMonitor monitor)
             throws CoreException {
         // Use the regular import and then configure as Maven
-        System.out.println("=== Creating project and configuring Maven ===");
+        VaadinPluginLog.info("=== Creating project and configuring Maven ===");
 
         // First create the project normally
         IProject project = importProject(projectPath, projectName, monitor);
@@ -247,12 +248,11 @@ public class NewVaadinProjectWizard extends Wizard implements INewWizard {
             // Additional refresh to ensure all resources are visible
             project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
 
-            System.out.println("Maven nature enabled and project configured with forced update");
-            System.out.println("Has Maven nature: " + project.hasNature("org.eclipse.m2e.core.maven2Nature"));
+            VaadinPluginLog.info("Maven nature enabled and project configured with forced update");
+            VaadinPluginLog.debug("Has Maven nature: " + project.hasNature("org.eclipse.m2e.core.maven2Nature"));
 
         } catch (Exception e) {
-            System.err.println("Failed to configure Maven nature: " + e.getMessage());
-            e.printStackTrace();
+            VaadinPluginLog.error("Failed to configure Maven nature: " + e.getMessage(), e);
         }
 
         return project;
@@ -260,9 +260,9 @@ public class NewVaadinProjectWizard extends Wizard implements INewWizard {
 
     private IProject importGradleProject(Path projectPath, String projectName, IProgressMonitor monitor)
             throws CoreException {
-        System.out.println("=== Importing Gradle project ===");
-        System.out.println("Project path: " + projectPath);
-        System.out.println("Project name: " + projectName);
+        VaadinPluginLog.info("=== Importing Gradle project ===");
+        VaadinPluginLog.debug("Project path: " + projectPath);
+        VaadinPluginLog.debug("Project name: " + projectName);
 
         IProject project = null;
 
@@ -271,14 +271,13 @@ public class NewVaadinProjectWizard extends Wizard implements INewWizard {
             // This will throw NoClassDefFoundError if Buildship is not available
             project = importGradleProjectWithBuildship(projectPath, projectName, monitor);
             if (project != null) {
-                System.out.println("Gradle project imported with Buildship successfully");
+                VaadinPluginLog.info("Gradle project imported with Buildship successfully");
                 return project;
             }
         } catch (NoClassDefFoundError | ClassNotFoundException e) {
-            System.out.println("Buildship not available, using basic Gradle configuration");
+            VaadinPluginLog.info("Buildship not available, using basic Gradle configuration");
         } catch (Exception e) {
-            System.err.println("Failed to import Gradle project with Buildship: " + e.getMessage());
-            e.printStackTrace();
+            VaadinPluginLog.error("Failed to import Gradle project with Buildship: " + e.getMessage(), e);
         }
 
         // Fall back to basic import
@@ -377,9 +376,9 @@ public class NewVaadinProjectWizard extends Wizard implements INewWizard {
 
     private IProject importProject(Path projectPath, String projectName, IProgressMonitor monitor)
             throws CoreException {
-        System.out.println("=== Using regular Eclipse project import ===");
-        System.out.println("Project path: " + projectPath);
-        System.out.println("Project name: " + projectName);
+        VaadinPluginLog.info("=== Using regular Eclipse project import ===");
+        VaadinPluginLog.debug("Project path: " + projectPath);
+        VaadinPluginLog.debug("Project name: " + projectName);
 
         IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
         IProject project = root.getProject(projectName);


### PR DESCRIPTION
- Created VaadinPluginLog utility class for centralized logging
- Replaced all System.out.println with appropriate log levels (info/debug)
- Replaced all System.err.println with VaadinPluginLog.error
- Replaced e.printStackTrace() with proper exception logging
- Uses Eclipse ILog framework for proper plugin integration
- Maintains same message content with appropriate severity levels
