### PR TITLE
fix: Rename debug configuration to 'Debug using Hotswap Agent'

### DIFF
--- a/vaadin-eclipse-plugin-main/plugin.xml
+++ b/vaadin-eclipse-plugin-main/plugin.xml
@@ -32,7 +32,7 @@
      <shortcut
            id="com.vaadin.plugin.hotswap.launchShortcut"
            class="com.vaadin.plugin.hotswap.HotswapLaunchShortcut"
-           label="Vaadin Application"
+           label="Debug using Hotswap Agent"
            icon="icons/vaadin.png"
            modes="debug">
         <contextualLaunch>


### PR DESCRIPTION
Changed the debug configuration label from 'Vaadin Application' to 'Debug using Hotswap Agent' to better describe what the debug action does and make it clearer for users.
