### PR TITLE
fix: Fix Copilot getModulePaths NullPointerException on Windows

### DIFF
--- a/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/CopilotRestService.java
+++ b/vaadin-eclipse-plugin-main/src/com/vaadin/plugin/CopilotRestService.java
@@ -196,7 +196,8 @@ public class CopilotRestService {
         private String handleCommand(String command, String projectBasePath, JsonObject data) {
             VaadinPluginLog.debug("Handling command: " + command + " for project: " + projectBasePath);
 
-            // Special case for getModulePaths - it should return an empty project structure if project not found
+            // Special case for getModulePaths - it should return an empty project structure
+            // if project not found
             if ("getModulePaths".equals(command)) {
                 return handleGetModulePaths(projectBasePath);
             }
@@ -250,16 +251,17 @@ public class CopilotRestService {
             IProject[] projects = ResourcesPlugin.getWorkspace().getRoot().getProjects();
             for (IProject project : projects) {
                 if (project.getLocation() != null) {
-                    // Compare both portable string (forward slashes) and OS string (native separators)
+                    // Compare both portable string (forward slashes) and OS string (native
+                    // separators)
                     String projectLocationPortable = project.getLocation().toPortableString();
                     String projectLocationOS = project.getLocation().toOSString();
-                    
+
                     // Normalize the input path for comparison
                     String normalizedBasePath = projectBasePath.replace('\\', '/');
-                    
-                    if (projectLocationPortable.equals(projectBasePath) || 
-                        projectLocationPortable.equals(normalizedBasePath) ||
-                        projectLocationOS.equals(projectBasePath)) {
+
+                    if (projectLocationPortable.equals(projectBasePath)
+                            || projectLocationPortable.equals(normalizedBasePath)
+                            || projectLocationOS.equals(projectBasePath)) {
                         return project;
                     }
                 }
@@ -642,14 +644,14 @@ public class CopilotRestService {
 
         private String handleGetModulePaths(String projectBasePath) {
             VaadinPluginLog.debug("GetModulePaths command for project path: " + projectBasePath);
-            
+
             Map<String, Object> response = new HashMap<>();
             Map<String, Object> projectInfo = new HashMap<>();
             List<Map<String, Object>> modules = new ArrayList<>();
-            
+
             // Find the project
             IProject project = findProject(projectBasePath);
-            
+
             if (project == null) {
                 VaadinPluginLog.warning("Project not found for getModulePaths: " + projectBasePath);
                 // Return empty but valid structure - Copilot expects a project object

--- a/vaadin-eclipse-plugin.tests/pom.xml
+++ b/vaadin-eclipse-plugin.tests/pom.xml
@@ -26,6 +26,7 @@
                 <configuration>
                     <useUIHarness>true</useUIHarness>
                     <useUIThread>true</useUIThread>
+                    <rerunFailingTestsCount>0</rerunFailingTestsCount>
                     <includes>
                         <include>**/*Test.java</include>
                         <include>**/AllTests.java</include>
@@ -54,6 +55,7 @@
                         <version>${tycho-version}</version>
                         <configuration>
                             <argLine>-XstartOnFirstThread</argLine>
+                            <rerunFailingTestsCount>0</rerunFailingTestsCount>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -76,6 +78,7 @@
                         <version>${tycho-version}</version>
                         <configuration>
                             <argLine>-Djava.awt.headless=true</argLine>
+                            <rerunFailingTestsCount>0</rerunFailingTestsCount>
                             <environmentVariables>
                                 <DISPLAY>:99</DISPLAY>
                             </environmentVariables>

--- a/vaadin-eclipse-plugin.tests/src/com/vaadin/plugin/test/AdvancedEndpointsTest.java
+++ b/vaadin-eclipse-plugin.tests/src/com/vaadin/plugin/test/AdvancedEndpointsTest.java
@@ -37,7 +37,7 @@ public class AdvancedEndpointsTest extends BaseIntegrationTest {
 		try {
 			restService.start();
 			String endpoint = restService.getEndpoint();
-			String projectPath = testProject.getLocation().toString();
+			String projectPath = testProject.getLocation().toOSString();
 
 			client = new CopilotClient(endpoint, projectPath);
 
@@ -128,7 +128,7 @@ public class AdvancedEndpointsTest extends BaseIntegrationTest {
 		createFile(testProject, "pom.xml", parentPomContent);
 
 		// Create module-a as a nested Eclipse project
-		String moduleALocation = testProject.getLocation().append("module-a").toString();
+		String moduleALocation = testProject.getLocation().append("module-a").toOSString();
 		org.eclipse.core.resources.IProject moduleA = createNestedProject("module-a", moduleALocation);
 
 		// Add Java nature to module-a
@@ -160,7 +160,7 @@ public class AdvancedEndpointsTest extends BaseIntegrationTest {
 		createFile(moduleA, "pom.xml", moduleAPomContent);
 
 		// Create module-b as another nested Eclipse project
-		String moduleBLocation = testProject.getLocation().append("module-b").toString();
+		String moduleBLocation = testProject.getLocation().append("module-b").toOSString();
 		org.eclipse.core.resources.IProject moduleB = createNestedProject("module-b", moduleBLocation);
 
 		// Add Java nature to module-b
@@ -202,7 +202,7 @@ public class AdvancedEndpointsTest extends BaseIntegrationTest {
 		assertTrue("Should have modules", project.has("modules"));
 
 		String basePath = project.get("basePath").getAsString();
-		assertEquals("Base path should be parent project", testProject.getLocation().toString(), basePath);
+		assertEquals("Base path should be parent project", testProject.getLocation().toOSString(), basePath);
 
 		// Verify multi-module structure
 		var modules = project.getAsJsonArray("modules");
@@ -276,7 +276,7 @@ public class AdvancedEndpointsTest extends BaseIntegrationTest {
 		// Test compile endpoint
 		JsonObject data = new JsonObject();
 		var filesArray = new com.google.gson.JsonArray();
-		filesArray.add(javaFile.getLocation().toString());
+		filesArray.add(javaFile.getLocation().toOSString());
 		data.add("files", filesArray);
 
 		HttpResponse<String> response = client.sendCommand("compileFiles", data);
@@ -431,7 +431,7 @@ public class AdvancedEndpointsTest extends BaseIntegrationTest {
 
 		// Modify via write endpoint to record operation
 		JsonObject writeData = new JsonObject();
-		writeData.addProperty("file", file.getLocation().toString());
+		writeData.addProperty("file", file.getLocation().toOSString());
 		writeData.addProperty("content", "Modified");
 		writeData.addProperty("undoLabel", "Test modification");
 
@@ -440,7 +440,7 @@ public class AdvancedEndpointsTest extends BaseIntegrationTest {
 		// Now test undo
 		JsonObject undoData = new JsonObject();
 		var filesArray = new com.google.gson.JsonArray();
-		filesArray.add(file.getLocation().toString());
+		filesArray.add(file.getLocation().toOSString());
 		undoData.add("files", filesArray);
 
 		HttpResponse<String> response = client.sendCommand("undo", undoData);

--- a/vaadin-eclipse-plugin.tests/src/com/vaadin/plugin/test/AdvancedEndpointsTest.java
+++ b/vaadin-eclipse-plugin.tests/src/com/vaadin/plugin/test/AdvancedEndpointsTest.java
@@ -228,7 +228,7 @@ public class AdvancedEndpointsTest extends BaseIntegrationTest {
 				assertEquals("Module A should have one content root", 1, contentRoots.size());
 				String contentRoot = contentRoots.get(0).getAsString();
 				assertTrue("Module A content root should be nested in parent",
-						contentRoot.contains(testProject.getName() + "/module-a"));
+						contentRoot.contains(testProject.getName() + java.io.File.separator + "module-a"));
 			} else if ("module-b".equals(moduleName)) {
 				foundModuleB = true;
 				assertTrue("Module B should have contentRoots", module.has("contentRoots"));
@@ -236,7 +236,7 @@ public class AdvancedEndpointsTest extends BaseIntegrationTest {
 				assertEquals("Module B should have one content root", 1, contentRoots.size());
 				String contentRoot = contentRoots.get(0).getAsString();
 				assertTrue("Module B content root should be nested in parent",
-						contentRoot.contains(testProject.getName() + "/module-b"));
+						contentRoot.contains(testProject.getName() + java.io.File.separator + "module-b"));
 			}
 		}
 


### PR DESCRIPTION
- Improve project path comparison to handle Windows backslashes
- Return valid empty structure when project not found instead of error
- Use OS-specific path format (toOSString) in responses for consistency
- Handle getModulePaths command before checking project existence
