### PR TITLE
docs: Document JSON native path convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,14 @@ vaadin-eclipse-plugin.tests/target/surefire-reports/
 - Use existing patterns and libraries
 - Run `mvn spotless:apply` to format the code
 
+## JSON Communication Convention
+- **IMPORTANT**: All JSON communication uses native OS file paths, not portable paths
+- Use `toOSString()` when writing paths to JSON (not `toPortableString()`)
+- On Windows: paths will have backslashes (e.g., `C:\Users\project`)
+- On Unix/Mac: paths will have forward slashes (e.g., `/home/user/project`)
+- When parsing JSON, backslashes are escaped in the raw JSON but parsed correctly
+- This applies to all JSON files including `flow-build-info.json` and REST API responses
+
 ## Key Test Classes
 - `ProjectModelTest` - Tests URL generation for project creation
 - `CopilotUndoManagerTest` - Tests undo/redo functionality

--- a/vaadin-eclipse-plugin-main/README.md
+++ b/vaadin-eclipse-plugin-main/README.md
@@ -1,0 +1,52 @@
+# Vaadin Eclipse Plugin - Main Module
+
+This is the main Eclipse plugin module for Vaadin support.
+
+## Architecture Decisions
+
+### JSON Path Convention
+
+**All JSON communication in this plugin uses native OS file paths, not portable paths.**
+
+This is a critical architectural decision that affects:
+- REST API responses (CopilotRestService)
+- Generated JSON files (flow-build-info.json)
+- Inter-process communication with Vaadin Copilot
+
+#### Implementation Guidelines
+
+1. **Writing paths to JSON**: Always use `toOSString()` method
+   ```java
+   String path = project.getLocation().toOSString();  // ✓ Correct
+   String path = project.getLocation().toPortableString();  // ✗ Wrong
+   ```
+
+2. **Expected path formats**:
+   - Windows: `C:\Users\username\project` (backslashes)
+   - Unix/Mac: `/home/username/project` (forward slashes)
+
+3. **JSON escaping**: When paths are written to JSON, backslashes are automatically escaped:
+   - Actual path: `C:\Users\project`
+   - In JSON: `"path": "C:\\Users\\project"`
+   - When parsed: `C:\Users\project`
+
+4. **Testing**: When testing JSON content, parse the JSON to compare actual values rather than string matching:
+   ```java
+   JsonObject json = JsonParser.parseString(jsonContent).getAsJsonObject();
+   String path = json.get("npmFolder").getAsString();
+   assertEquals(expected, path);  // Handles escaping correctly
+   ```
+
+## Key Components
+
+- **CopilotRestService**: REST API server for Copilot integration
+- **VaadinBuildParticipant**: Eclipse build participant that generates flow-build-info.json
+- **VaadinBuilderConfigurator**: Manages Eclipse builder configuration
+- **VaadinProjectWizard**: New project creation wizard
+
+## Testing
+
+Tests are located in the `vaadin-eclipse-plugin.tests` module. Run with:
+```bash
+mvn verify
+```


### PR DESCRIPTION
- Added section in CLAUDE.md about JSON path convention
- Created README.md in main plugin module with architecture decisions
- Documented that all JSON uses toOSString() for native OS paths
- Explained JSON escaping behavior and proper testing approach
