### PR TITLE
test: Add SLF4J implementation to suppress warnings in tests

### DIFF
--- a/vaadin-eclipse-plugin.tests/pom.xml
+++ b/vaadin-eclipse-plugin.tests/pom.xml
@@ -33,6 +33,14 @@
                     </includes>
                     <!-- Don't specify product/application, let Eclipse use defaults -->
                     <!-- argLine is set by profiles based on OS -->
+                    <!-- Add SLF4J implementation to suppress warning -->
+                    <dependencies>
+                        <dependency>
+                            <type>eclipse-plugin</type>
+                            <artifactId>org.slf4j.simple</artifactId>
+                            <version>0.0.0</version>
+                        </dependency>
+                    </dependencies>
                 </configuration>
             </plugin>
         </plugins>
@@ -56,6 +64,14 @@
                         <configuration>
                             <argLine>-XstartOnFirstThread</argLine>
                             <rerunFailingTestsCount>0</rerunFailingTestsCount>
+                            <!-- Add SLF4J implementation to suppress warning -->
+                            <dependencies>
+                                <dependency>
+                                    <type>eclipse-plugin</type>
+                                    <artifactId>org.slf4j.simple</artifactId>
+                                    <version>0.0.0</version>
+                                </dependency>
+                            </dependencies>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -82,6 +98,14 @@
                             <environmentVariables>
                                 <DISPLAY>:99</DISPLAY>
                             </environmentVariables>
+                            <!-- Add SLF4J implementation to suppress warning -->
+                            <dependencies>
+                                <dependency>
+                                    <type>eclipse-plugin</type>
+                                    <artifactId>org.slf4j.simple</artifactId>
+                                    <version>0.0.0</version>
+                                </dependency>
+                            </dependencies>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/vaadin-eclipse-plugin.tests/pom.xml
+++ b/vaadin-eclipse-plugin.tests/pom.xml
@@ -33,11 +33,21 @@
                     </includes>
                     <!-- Don't specify product/application, let Eclipse use defaults -->
                     <!-- argLine is set by profiles based on OS -->
-                    <!-- Add SLF4J implementation to suppress warning -->
+                    <!-- Add SLF4J implementation to see log messages during tests -->
                     <dependencies>
                         <dependency>
                             <type>eclipse-plugin</type>
-                            <artifactId>org.slf4j.simple</artifactId>
+                            <artifactId>org.slf4j.api</artifactId>
+                            <version>0.0.0</version>
+                        </dependency>
+                        <dependency>
+                            <type>eclipse-plugin</type>
+                            <artifactId>ch.qos.logback.classic</artifactId>
+                            <version>0.0.0</version>
+                        </dependency>
+                        <dependency>
+                            <type>eclipse-plugin</type>
+                            <artifactId>ch.qos.logback.core</artifactId>
                             <version>0.0.0</version>
                         </dependency>
                     </dependencies>
@@ -64,11 +74,20 @@
                         <configuration>
                             <argLine>-XstartOnFirstThread</argLine>
                             <rerunFailingTestsCount>0</rerunFailingTestsCount>
-                            <!-- Add SLF4J implementation to suppress warning -->
                             <dependencies>
                                 <dependency>
                                     <type>eclipse-plugin</type>
-                                    <artifactId>org.slf4j.simple</artifactId>
+                                    <artifactId>org.slf4j.api</artifactId>
+                                    <version>0.0.0</version>
+                                </dependency>
+                                <dependency>
+                                    <type>eclipse-plugin</type>
+                                    <artifactId>ch.qos.logback.classic</artifactId>
+                                    <version>0.0.0</version>
+                                </dependency>
+                                <dependency>
+                                    <type>eclipse-plugin</type>
+                                    <artifactId>ch.qos.logback.core</artifactId>
                                     <version>0.0.0</version>
                                 </dependency>
                             </dependencies>
@@ -98,11 +117,20 @@
                             <environmentVariables>
                                 <DISPLAY>:99</DISPLAY>
                             </environmentVariables>
-                            <!-- Add SLF4J implementation to suppress warning -->
                             <dependencies>
                                 <dependency>
                                     <type>eclipse-plugin</type>
-                                    <artifactId>org.slf4j.simple</artifactId>
+                                    <artifactId>org.slf4j.api</artifactId>
+                                    <version>0.0.0</version>
+                                </dependency>
+                                <dependency>
+                                    <type>eclipse-plugin</type>
+                                    <artifactId>ch.qos.logback.classic</artifactId>
+                                    <version>0.0.0</version>
+                                </dependency>
+                                <dependency>
+                                    <type>eclipse-plugin</type>
+                                    <artifactId>ch.qos.logback.core</artifactId>
                                     <version>0.0.0</version>
                                 </dependency>
                             </dependencies>


### PR DESCRIPTION
Added org.slf4j.simple as a dependency to tycho-surefire-plugin to suppress SLF4J warnings about missing providers during test execution.

The SLF4J dependency is added to:
- Main plugin configuration
- macOS profile configuration
- non-macOS profile configuration

This eliminates the warning messages:
"SLF4J(W): No SLF4J providers were found."
