### PR TITLE
fix: Suppress Eclipse E4 javax annotation warnings in tests

### DIFF
--- a/vaadin-eclipse-plugin.tests/pom.xml
+++ b/vaadin-eclipse-plugin.tests/pom.xml
@@ -54,7 +54,7 @@
                         <artifactId>tycho-surefire-plugin</artifactId>
                         <version>${tycho-version}</version>
                         <configuration>
-                            <argLine>-XstartOnFirstThread</argLine>
+                            <argLine>-XstartOnFirstThread -Declipse.e4.inject.javax.warning=false</argLine>
                             <rerunFailingTestsCount>0</rerunFailingTestsCount>
                         </configuration>
                     </plugin>
@@ -77,7 +77,7 @@
                         <artifactId>tycho-surefire-plugin</artifactId>
                         <version>${tycho-version}</version>
                         <configuration>
-                            <argLine>-Djava.awt.headless=true</argLine>
+                            <argLine>-Djava.awt.headless=true -Declipse.e4.inject.javax.warning=false</argLine>
                             <rerunFailingTestsCount>0</rerunFailingTestsCount>
                             <environmentVariables>
                                 <DISPLAY>:99</DISPLAY>


### PR DESCRIPTION
Added -Declipse.e4.inject.javax.warning=false to suppress warnings about javax.inject and javax.annotation packages. These warnings come from the Eclipse platform itself, not our code, and cannot be fixed by upgrading to Jakarta annotations since Eclipse 2024-03 still uses javax internally.

The flag is added to both macOS and non-macOS profile configurations.

This eliminates the warning:
"WARNING: Annotation classes from the 'javax.inject' or 'javax.annotation' package found. It is recommended to migrate to the corresponding replacements in the jakarta namespace."
